### PR TITLE
docs: point PyPI project links at the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 Versions are derived from Git tags via `setuptools_scm` — see [VERSIONING.md](VERSIONING.md).
 
+## 2.0.1
+
+### Changed
+
+- PyPI project links now point at the product rather than only at the repository. `Homepage` is
+  `https://wavespeed.ai` (it was the GitHub repo), and `Documentation` and `Changelog` entries were
+  added. No code changes — packaging metadata only.
+
 ## 2.0.0
 
 ### Removed — BREAKING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/WaveSpeedAI/wavespeed-python"
+Homepage = "https://wavespeed.ai"
+Documentation = "https://wavespeed.ai/docs/"
 Repository = "https://github.com/WaveSpeedAI/wavespeed-python"
 Issues = "https://github.com/WaveSpeedAI/wavespeed-python/issues"
+Changelog = "https://github.com/WaveSpeedAI/wavespeed-python/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
`[project.urls]` had all three entries pointing at GitHub, so [pypi.org/project/wavespeed](https://pypi.org/project/wavespeed/) — the landing page for our most-downloaded package (~1,535/week) — offered no route to the product or the docs.

```toml
[project.urls]
Homepage = "https://wavespeed.ai"              # was the GitHub repo
Documentation = "https://wavespeed.ai/docs/"   # new
Repository = "https://github.com/WaveSpeedAI/wavespeed-python"
Issues = "https://github.com/WaveSpeedAI/wavespeed-python/issues"
Changelog = "https://github.com/WaveSpeedAI/wavespeed-python/blob/main/CHANGELOG.md"  # new
```

**Why these five labels.** Checked against live PyPI pages (httpx, fastapi, pydantic) — these are the names Warehouse renders with an icon:

| Label | Icon |
| - | - |
| `Homepage` | home |
| `Documentation` | book |
| `Repository` / `Source` | GitHub |
| `Issues` | bug |
| `Changelog` | scroll |

Anything else renders as a plain link. PyPI sorts them **alphabetically**, not by declaration order, so ordering here is cosmetic.

**Verified:** TOML parses; all four URLs return 200 (`/docs` resolves to `/docs/`); `CHANGELOG.md` is present on `main`.

**Note:** the PyPI page shows metadata from the *latest release*, so this only becomes visible after a `v2.0.1` tag. CHANGELOG entry added accordingly.