### PR TITLE
ci: publish on tag push instead of the release event

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,9 +8,15 @@
 
 name: python-publish
 
+# Triggered by the tag push itself, not by the GitHub Release.
+# python-packages.yml creates that Release using GITHUB_TOKEN, and GitHub's
+# anti-recursion rule means events produced by GITHUB_TOKEN never start another
+# workflow — so `release: published` silently never fired here and the package
+# was never uploaded, while every other check went green.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v[0-9]+*"
   workflow_dispatch:
 
 permissions:
@@ -20,7 +26,7 @@ jobs:
   deploy:
     if: >-
       github.repository == 'WaveSpeedAI/wavespeed-python' &&
-      ((github.event_name == 'release' && github.ref_type == 'tag' &&
+      ((github.event_name == 'push' && github.ref_type == 'tag' &&
         startsWith(github.ref, 'refs/tags/v')) ||
        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
`python-publish.yml` triggers on `release: published`, but that event never reaches it.

`python-packages.yml` creates the GitHub Release on tag push using `GITHUB_TOKEN`, and **GitHub deliberately does not start new workflow runs from events produced by `GITHUB_TOKEN`** (the anti-recursion rule). So the Release appears, every other check goes green, and the package is silently never uploaded.

This bit `wavespeed` twice — 2.0.0 and again at 2.0.1 today. Both times the fix was manual: delete and recreate the Release, or `workflow_dispatch` on `main`.

```diff
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v[0-9]+*"
   workflow_dispatch:
```

with the job `if` updated from `github.event_name == 'release'` to `== 'push'`.

**A tag push is a real user action**, so it triggers workflows normally. `workflow_dispatch` on `main` stays as the escape hatch.

`release: published` is **replaced rather than kept alongside**: keeping both would let a manually-created Release and a tag push each fire an upload of the same version, and the second would fail against PyPI. One unambiguous trigger is better than two that mostly do not overlap.

Workflow file only — the build and trusted-publishing steps are untouched.